### PR TITLE
Updated the default value of app.kubernetes.io/managed-by from "helm"…

### DIFF
--- a/charts/dapr/values.yaml
+++ b/charts/dapr/values.yaml
@@ -83,7 +83,7 @@ global:
     app.kubernetes.io/name: "{{ .Release.Name }}"
     app.kubernetes.io/version: "{{ .Values.global.tag }}"
     app.kubernetes.io/part-of: "dapr"
-    app.kubernetes.io/managed-by: "helm"
+    app.kubernetes.io/managed-by: "{{ .Release.Service }}"
     app.kubernetes.io/component: "{{ .Values.component }}" # Should be set in each subchart
 
   issuerFilenames: {}


### PR DESCRIPTION
… to  {{ .Release.Service }}

# Description

Standardized the way in whitch the label `app.kubernetes.io/managed-by` is populated to avoid writing the value **helm** with the **'H'** lower case, witch causes an infinite patch loop when the chart is deployed with GitOps (in that case Fleet).

HELM DOCS: [https://helm.sh/docs/chart_best_practices/labels/](https://helm.sh/docs/chart_best_practices/labels/)

## Issue reference

- (https://github.com/rancher/fleet/issues/2784)


## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
